### PR TITLE
feat: set up English documentation structure and start experimental translation

### DIFF
--- a/docs/en/source/answers/data/003.rst
+++ b/docs/en/source/answers/data/003.rst
@@ -1,0 +1,82 @@
+How to parse Apollo Record files?
+======================
+
+How to parse Apollo Record files (e.g., extract point cloud, image messages)?
+
+-  Maintainer: \ daohu527@gmail.com, yhuai@uci.edu
+-  Version：1.0.0
+-  Date：06/05/2024
+-  Description：Translated from Chinese documentation
+
+Answer
+----
+
+`cyber_recorder <https://cyber-rt.readthedocs.io/en/latest/CyberRT_Developer_Tools.html>`_ \ can be used to record messages published by each module of Apollo at run time,
+saves those messages in record file(s), and users can extract data from the record file(s)
+for model training, problem analysis, etc.
+
+How to extract data from the record file(s)?
+
+Installation
+~~~~
+
+``cyber_record`` \ is a Python implementation of Apollo Record read/write tool,
+it provides both command line and API interfaces. It is a light weight cross-platform tool,
+with a disadvantage of slow speed.
+
+.. code:: shell
+
+   pip3 install cyber_record record_msg
+
+Read Images
+~~~~~~~~
+
+Specify the name of the ``topic`` to read image from,
+and the path ``output_path`` to save the image.
+Then, run the following code.
+
+.. code:: python
+
+   from cyber_record.record import Record
+   from record_msg.parser import ImageParser
+
+   image_parser = ImageParser(output_path='../test')
+   for topic, message, t in record.read_messages():
+     if topic == "/apollo/sensor/camera/front_6mm/image":
+       image_parser.parse(message)
+       # or use timestamp as image file name
+       # image_parser.parse(image, t)
+
+Read Point Cloud
+~~~~~~~~
+
+Specify the name of the ``topic`` to read point cloud from,
+and the path ``output_path`` to save the point cloud.
+Then, run the following code.
+
+.. code:: python
+
+   from cyber_record.record import Record
+   from record_msg.parser import PointCloudParser
+
+   pointcloud_parser = PointCloudParser('../test')
+   for topic, message, t in record.read_messages():
+     if topic == "/apollo/sensor/lidar32/compensator/PointCloud2":
+       pointcloud_parser.parse(message)
+       # other modes, default is 'ascii'
+       # pointcloud_parser.parse(message, mode='binary')
+       # pointcloud_parser.parse(message, mode='binary_compressed')
+
+
+Increasing Reading Speed
+~~~~~~~~
+
+For faster reading, you can use filter to read messages from a specific topic or within a specific time range.
+
+.. code:: python
+
+   def read_filter_by_both():
+     record = Record(file_name)
+     for topic, message, t in record.read_messages('/apollo/canbus/chassis', \
+         start_time=1627031535164278940, end_time=1627031535215164773):
+       print("{}, {}, {}".format(topic, type(message), t))

--- a/docs/en/source/answers/data/003.rst
+++ b/docs/en/source/answers/data/003.rst
@@ -6,7 +6,7 @@ How to parse Apollo Record files (e.g., extract point cloud, image messages)?
 -  Maintainer: \ daohu527@gmail.com, yhuai@uci.edu
 -  Version：1.0.0
 -  Date：06/05/2024
--  Description：Translated from Chinese documentation
+-  Description：This document introduces how to extract data from Apollo Record files.
 
 Answer
 ----

--- a/docs/en/source/answers/data/004.rst
+++ b/docs/en/source/answers/data/004.rst
@@ -1,0 +1,55 @@
+How to convert between Ros Bag and Apollo Record?
+============================
+
+How to convert Ros Bag into Apollo Record, and how to convert Apollo Record back into Ros Bag?
+
+-  Maintainer：\ daohu527@gmail.com, yhuai@uci.edu
+-  Version：1.0.0
+-  Date：06/05/2024
+-  Description：Translated from Chinese documentation
+
+Answer
+----
+
+Ros Bag and Apollo Record are two different data storage formats.
+Because these two formats have differences in file structure and message definition,
+data conversion is required.
+
+The process of conversion can be summarized into the following three key steps:
+
+1. **Read ROS Bag Data**\ : First, we need to open the ROS Bag file using the corresponding tool or library,
+   and read the stored ROS messages. In this step, we will get the type of ROS messages, and prepare for the subsequent conversion.
+
+2. **Convert Message Format**\ : After reading the ROS messages, we need to convert these messages from ROS 
+    format to the format supported by the Apollo. This usually involves parsing the content of ROS messages, 
+    and reorganizing this data according to the message definition of Apollo.
+
+3. **Save as Apollo Record**\ : After completing the conversion of the message format, we will save the new Apollo 
+    messages as an Apollo Record file. By completing this step, messages collected from the original ROS system can
+    now be read and used by Apollo.
+
+To simplify the process described above, we provide the ``bag_convert`` tool. 
+With this tool, users only need to specify the path of the ROS Bag file and the 
+path of the output Apollo Record file, and the data format conversion can be easily completed.
+
+
+Installation
+~~~~
+
+.. code:: shell
+
+   pip3 install bag_convert
+
+Ros Bag to Apollo Record
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: shell
+
+   bag_convert -m=b2r -b=data/input.bag -r=data/output.record
+
+Apollo Record to Ros Bag
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: shell
+
+   bag_convert -m=r2b -r=data/input.record -b=data/output.bag

--- a/docs/en/source/answers/data/004.rst
+++ b/docs/en/source/answers/data/004.rst
@@ -6,7 +6,7 @@ How to convert Ros Bag into Apollo Record, and how to convert Apollo Record back
 -  Maintainer：\ daohu527@gmail.com, yhuai@uci.edu
 -  Version：1.0.0
 -  Date：06/05/2024
--  Description：Translated from Chinese documentation
+-  Description：This document describes necessary tools and steps to convert data between Ros Bag and Apollo Record.
 
 Answer
 ----

--- a/docs/en/source/index.rst
+++ b/docs/en/source/index.rst
@@ -36,58 +36,9 @@ and will gradually add answers. Hope it helps you!
    We are currently improving the Chinese version and will translate it
    into English later.
 
-Contents
---------
+.. toctree::
+   :numbered:
+   :maxdepth: 2
+   :caption: Contents:
 
--  `Hardware <#hardware>`__
--  `Cyber <#cyber>`__
--  `Localization <#localization>`__
--  `Perception <#perception>`__
--  `Prediction <#prediction>`__
--  `Routing <#routing>`__
--  `Planning <#planning>`__
--  `Control <#control>`__
--  `Transform <#transform>`__
--  `Map <#map>`__
--  `Dreamview <#dreamview>`__
--  `Tools <#tools>`__
--  `Misc <#misc>`__
-
-Hardware
---------
-
-Cyber
------
-
-Localization
-------------
-
-Perception
-----------
-
-Prediction
-----------
-
-Routing
--------
-
-Planning
---------
-
-Control
--------
-
-Transform
----------
-
-Map
----
-
-Dreamview
----------
-
-Tools
------
-
-Misc
-----
+   questions

--- a/docs/en/source/questions.rst
+++ b/docs/en/source/questions.rst
@@ -1,0 +1,159 @@
+Basic
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/basic/*
+
+Hardware
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/hardware/*
+
+CyberRT
+------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/cyber/*
+
+Data
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/data/*
+
+Localization
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/localization/*
+
+Perception
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/perception/*
+
+Prediction
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/prediction/*
+
+Routing
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/routing/*
+
+Planning
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/planning/*
+
+Control
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/control/*
+
+Transform
+--------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/transform/*
+
+HD Map
+----------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/hdmap/*
+
+Simulation
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/simulation/*
+
+Dreamview
+----------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/dreamview/*
+
+Tools
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/tools/*
+
+Misc
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/misc/*


### PR DESCRIPTION
In this pull request, I structured `en` documentation according to the current `zh-cn` documentation and started trying to translate 2 of the documentation into English.

I am seeing a potential problem as in the Chinese documentation, `Apollo Record`, `Cyber Record`, and `Record` are all used to refer to the record file produced by `cyber_recorder`. This is probably fine for experienced users, but for a newcomer, this might cause confusion.

I suggest using `Apollo Record` since messages in those record files are defined by Apollo and theoretically CyberRT can be used by another ADS system recording messages defined by that ADS (e.g., Seahorse Record).