### PR TITLE
feat: create japanese docs dir

### DIFF
--- a/docs/ja/.readthedocs.yaml
+++ b/docs/ja/.readthedocs.yaml
@@ -1,0 +1,30 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/jp/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+   - epub
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/ja/Makefile
+++ b/docs/ja/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/ja/make.bat
+++ b/docs/ja/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/ja/source/conf.py
+++ b/docs/ja/source/conf.py
@@ -1,0 +1,62 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Apollo 1000 Questions'
+copyright = '2024, ApolloAuto'
+author = 'ApolloAuto'
+
+# The full version, including alpha/beta/rc tags
+release = '1.0.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+  'myst_parser',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'restructuredtext',
+    '.md': 'markdown',
+}

--- a/docs/ja/source/index.rst
+++ b/docs/ja/source/index.rst
@@ -1,0 +1,43 @@
+.. Apollo 1000 Questions documentation master file, created by
+   sphinx-quickstart on Mon May 13 10:39:19 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+=====================
+Apollo 1000 Questions
+=====================
+
+`English <https://apollo-1000-questions.readthedocs.io/en/latest/>`__
+\| `中文 <https://apollo-1000-questions.readthedocs.io/zh/latest/>`__
+\| `한국어 <https://apollo-1000-questions.readthedocs.io/ko/latest/>`__
+\| `日本語 <https://apollo-1000-questions.readthedocs.io/ja/latest/>`__
+
+.. raw:: html
+
+   <p>
+   <a href="https://discord.gg/nf3NmuvZ">
+         <img src="https://img.shields.io/discord/1237738060175769601?style=social&logo=discord" alt="Chat with us without signup" title="Chat with us without signup">
+   </a>
+   <a href='https://apollo-1000-questions.readthedocs.io/en/latest/?badge=latest'>
+         <img src='https://readthedocs.org/projects/apollo-1000-questions/badge/?version=latest' alt='Documentation Status' />
+   </a>
+   <a href="https://github.com/ApolloAuto/Apollo-1000-questions/blob/main/LICENSE" alt="License">
+      <img src="https://img.shields.io/github/license/ApolloAuto/Apollo-1000-questions">
+   </a>
+   </p>
+
+
+`Apollo <https://github.com/ApolloAuto/apollo>`__. について多くの疑問をお持ちであることは承知しています。
+ここでは Apollo に関する 1000 の質問をまとめました。これだけでは十分ではないことは承知しており、
+回答は徐々に追加していきます。お役に立てれば幸いです。
+
+..
+
+   現在、中国語版を改良しており、後日日本語にも翻訳する予定です。 
+
+.. toctree::
+   :numbered:
+   :maxdepth: 2
+   :caption: Contents:
+
+   questions

--- a/docs/ja/source/questions.rst
+++ b/docs/ja/source/questions.rst
@@ -1,0 +1,159 @@
+Basic
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/basic/*
+
+Hardware
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/hardware/*
+
+CyberRT
+------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/cyber/*
+
+Data
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/data/*
+
+Localization
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/localization/*
+
+Perception
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/perception/*
+
+Prediction
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/prediction/*
+
+Routing
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/routing/*
+
+Planning
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/planning/*
+
+Control
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/control/*
+
+Transform
+--------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/transform/*
+
+HD Map
+----------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/hdmap/*
+
+Simulation
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/simulation/*
+
+Dreamview
+----------
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/dreamview/*
+
+Tools
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/tools/*
+
+Misc
+----
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+   :glob:
+
+   answers/misc/*


### PR DESCRIPTION
In this PR, I created a `ja` directory within `docs/` to add Japanese translation and followed the `zh-cn` documentation structure. 

Currently, there is no translation of documents into Japanese. 
